### PR TITLE
Exclude empty libs modules from Eclipse classpath

### DIFF
--- a/eclipse.gradle.kts
+++ b/eclipse.gradle.kts
@@ -17,6 +17,7 @@ val sourcePluginProjects =
         .map { it.path }
         .filter { it.startsWith(":libs:") }
         .distinct()
+val sourcePluginProjectNames = sourcePluginProjects.map { it.substringAfterLast(":") }.toSet()
 sourcePluginProjects.forEach { evaluationDependsOn(it) }
 
 val ideLibs: Configuration by
@@ -94,8 +95,10 @@ val injectIdeLibs =
                 val kind = n.attributes?.getNamedItem("kind")?.nodeValue
                 val p = n.attributes?.getNamedItem("path")?.nodeValue ?: ""
                 val isIdeLibEntry = kind == "lib" && (p == dirPath || p.startsWith("$dirPath/"))
+                val sourceProjectPath = p.removePrefix("/")
                 val isHalfImportedSourceModule = kind == "src" && p.startsWith("/libs:")
-                if (isIdeLibEntry || isHalfImportedSourceModule) {
+                val isSourcePluginModule = kind == "src" && sourceProjectPath in sourcePluginProjectNames
+                if (isIdeLibEntry || isHalfImportedSourceModule || isSourcePluginModule) {
                     toRemove += n
                 }
             }


### PR DESCRIPTION
### Motivation
- Prevent Eclipse from adding empty source-module entries for `:libs:` projects (e.g., `Utilities-OG`, `DiamondBank-OG`) so that only the built jar artifacts are used on the classpath.
- Remove broken/unresolved `src` classpath entries that interfere with Eclipse project imports while keeping the jar injection behavior intact.

### Description
- Compute the set of `:libs:` project names with `val sourcePluginProjectNames = sourcePluginProjects.map { it.substringAfterLast(":") }.toSet()`.
- Extend the classpath cleanup to remove `src` entries whose project path matches an entry in `sourcePluginProjectNames` by checking `val isSourcePluginModule = kind == "src" && sourceProjectPath in sourcePluginProjectNames` and removing those nodes.
- Preserve existing behavior that removes `ide-libs` directory entries and half-imported `/libs:` source refs, and keep appending the built jar entries last.

### Testing
- Ran `./gradlew eclipseClasspath --no-daemon` to exercise the Eclipse classpath generation, but the build failed in this environment with `25.0.1` (likely a local toolchain/JDK issue) so the change could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee48e9f68832f855c4bcce7feac27)